### PR TITLE
Fix Windows tkinter initialization error in CI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest configuration file for specification_curve tests."""
+
+import matplotlib
+
+# Set matplotlib to use non-interactive backend to avoid tkinter issues on CI
+# This must be done before importing pyplot
+matplotlib.use("Agg")


### PR DESCRIPTION
Adds conftest.py to set matplotlib backend to 'Agg' (non-interactive) before any tests run. This prevents tkinter initialisation errors on Windows CI environments where no display server is available.

Fixes test_025_fig_axes_further_adjustment failing with: _tkinter.TclError: Can't find a usable init.tcl